### PR TITLE
Fix lint missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "lint-python": "flake8 --exclude '*env*,node_modules' && black --line-length 79 --check --exclude '(node_modules/.*|[^/]*env[0-9]?/.*)' .",
     "format-python": "black --line-length 79 --exclude '(node_modules/.*|[^/]*env[0-9]?/.*)' .",
     "test-python": "./manage.py test webapp.tests",
-    "test": "yarn run lint && yarn run test-python"
+    "test": "yarn run test-python"
   }
 }


### PR DESCRIPTION
## Done
- Fix #131 
- Tried `./run test` it seems to be working fine
- If it doesn't please try with `./run clean-cache && ./run clean && ./run test`
- Test is failing because `package.json` is missing a lint script which I removed from `yarn run test`

## QA

- `./run clean-cache && ./run clean && ./run`
- `./run test`