### PR TITLE
Bug/renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,5 @@
       "depTypeList": ["devDependencies"],
       "extends": [":automergeMinor"]
     }
-  ],
-  "compatibility": {
-    "python": "2.7"
-  }
+  ]
 }


### PR DESCRIPTION
## Done

- [x] fix renovate configuration #132 
- [x] there is already an environment marker in `requirements.txt` no need to add this config to renovate

## QA
`./run clean && ./run build && ./run`

## Issue
Issue #132 