### PR TITLE
Cache-control:private for token-based endpoints

### DIFF
--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -22,6 +22,9 @@ def token_required(f):
             message = "Invalid or missing token."
             flask.abort(401, message)
 
-        return f(*args, **kwargs)
+        response = flask.make_response(f(*args, **kwargs))
+        response.cache_control.private = True
+
+        return response
 
     return wrapped


### PR DESCRIPTION
QA
--

Get a token:

```
./run exec flask token list
# or
./run exec flask token create mytoken
```

Run the site:

```
./run
```

Curl an auth'd endpoint:

```
$ curl -I "http://0.0.0.0:8017/tokens?token=YOURTOKEN"
HTTP/1.1 200 OK
...
Cache-Control: private
```

^ Check you see `cache-control: private`.