### PR TITLE
Add redirect views to flask app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
           name: Install dependencies
           command: pip3 install coverage
       - run:
+          name: Run migrations
+          command: alembic upgrade head
+      - run:
           name: Run tests with coverage
           command: |
             coverage run  --source=. -m unittest discover tests

--- a/entrypoint
+++ b/entrypoint
@@ -8,4 +8,8 @@ if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"
 fi
 
+# Run migrations
+alembic upgrade head
+
+# Start the website
 ${RUN_COMMAND}

--- a/webapp/alembic/versions/a2f0126f69b8_add_redirects.py
+++ b/webapp/alembic/versions/a2f0126f69b8_add_redirects.py
@@ -1,0 +1,31 @@
+"""add redirects
+
+Revision ID: a2f0126f69b8
+Revises: 2ab5564cfe99
+Create Date: 2020-01-14 14:46:21.862129
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a2f0126f69b8"
+down_revision = "2ab5564cfe99"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "redirect",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("redirect_path", sa.String(), nullable=False),
+        sa.Column("target_url", sa.String(), nullable=False),
+        sa.Column("permanent", sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("redirect")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -5,14 +5,19 @@ from canonicalwebteam.flask_base.app import FlaskBase
 from webapp.views import (
     create_asset,
     create_token,
+    create_redirect,
     delete_asset,
     delete_token,
+    delete_redirect,
     get_asset,
     get_assets,
     get_asset_info,
     get_tokens,
     get_token,
+    get_redirect,
+    get_redirects,
     update_asset,
+    update_redirect,
 )
 from webapp.database import db_session
 from webapp.commands import token_group
@@ -65,6 +70,16 @@ app.add_url_rule(
     "/tokens/<string:name>", view_func=delete_token, methods=["DELETE"]
 )
 
+# Redirects
+app.add_url_rule("/redirects", view_func=get_redirects)
+app.add_url_rule("/redirects", view_func=create_redirect, methods=["POST"])
+app.add_url_rule("/redirects/<redirect_path>", view_func=get_redirect)
+app.add_url_rule(
+    "/redirects/<redirect_path>", view_func=update_redirect, methods=["PUT"]
+)
+app.add_url_rule(
+    "/redirects/<redirect_path>", view_func=delete_redirect, methods=["DELETE"]
+)
 
 # Teardown
 # ===

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Integer, JSON, String
+from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
@@ -25,4 +25,20 @@ class Asset(Base):
             **self.data,
             "created": self.created.strftime("%a, %d %b %Y %H:%M:%S"),
             "file_path": self.file_path,
+        }
+
+
+class Redirect(Base):
+    __tablename__ = "redirect"
+
+    id = Column(Integer, primary_key=True)
+    redirect_path = Column(String, nullable=False)
+    target_url = Column(String, nullable=False)
+    permanent = Column(Boolean, nullable=False)
+
+    def as_json(self):
+        return {
+            "redirect_path": self.redirect_path,
+            "target_url": self.target_url,
+            "permanent": self.permanent,
         }


### PR DESCRIPTION
## Done
Port all the redirect views from django to flask.

## QA
- docker-compose up -d
- `./run exec alembic upgrade head`
- if you don't have one, create a token with `./run exec flask token create <token_name>`
- `./run`
- Create a redirect: `curl -H "Authorization: token <token>" --data "redirect_path=/here" --data "target_url=/there" http://localhost:8017/redirects `
- `curl -I localhost:8017/here` and make sure you are redirected to `localhost:8017/there`
- Update the redirect with: `curl -X PUT -H "Authorization: token <token>" --data "target_url=/there2" http://localhost:8017/redirects/here`
- `curl -I localhost:8017/here` and make sure you are redirected to `localhost:8017/there2`
- `curl -H "Authorization: token <token>" http://localhost:8017/redirects/here` and see the redirect you just created.
- `curl -H "Authorization: token <token>" http://localhost:8017/redirects` and see the redirect you just created as part of a 1 item list of redirects.
- `curl -X DELETE -H "Authorization: token <token>" http://localhost:8017/redirects/here` and then make sure the token was delete.
