### PR TITLE
Import redirects command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage: Install python dependencies
 # ===
-FROM ubuntu:focal AS python-dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
+FROM ubuntu:bionic AS python-dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes build-essential python3-dev python3-pip python3-setuptools python3-wheel libpq-dev
 ADD requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 
@@ -23,14 +23,13 @@ RUN yarn run build-css
 
 # Build the production image
 # ===
-FROM ubuntu:focal
+FROM ubuntu:bionic
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-setuptools python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev \
-# depencies for python requirements
-imagemagick libjpeg-progs optipng libmagic-dev
-
-COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
+RUN apt-get update && apt-get install --no-install-recommends --yes \
+python3-setuptools python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev \
+libpng-dev libjpeg-dev libjpeg-progs libmagic1 libmagickwand-dev optipng
+COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,12 +6,10 @@ services:
       POSTGRES_DB: assets
       POSTGRES_USER: assets
       POSTGRES_PASSWORD: password
-    network_mode: "host"
     ports: 
       - "5432:5432"
   swift:
     image: bouncestorage/swift-aio:latest
-    network_mode: "host"
     ports: 
       - "8080:8080"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ sh==1.14.2
 sqlalchemy==1.4.26
 Wand==0.6.7
 requests>=2.18.0
-Pillow==8.4.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -205,14 +205,12 @@ def error_swift(error=None):
 # Assets
 app.add_url_rule("/", view_func=get_assets)
 app.add_url_rule("/", view_func=create_asset, methods=["POST"])
-app.add_url_rule("/<string:file_path>", view_func=get_asset)
+app.add_url_rule("/<path:file_path>", view_func=get_asset)
+app.add_url_rule("/<path:file_path>", view_func=update_asset, methods=["PUT"])
 app.add_url_rule(
-    "/<string:file_path>", view_func=update_asset, methods=["PUT"]
+    "/<path:file_path>", view_func=delete_asset, methods=["DELETE"]
 )
-app.add_url_rule(
-    "/<string:file_path>", view_func=delete_asset, methods=["DELETE"]
-)
-app.add_url_rule("/<string:file_path>/info", view_func=get_asset_info)
+app.add_url_rule("/<path:file_path>/info", view_func=get_asset_info)
 
 # Tokens
 app.add_url_rule("/tokens", view_func=get_tokens)
@@ -227,14 +225,14 @@ app.add_url_rule(
 # Redirects
 app.add_url_rule("/redirects", view_func=get_redirects)
 app.add_url_rule("/redirects", view_func=create_redirect, methods=["POST"])
-app.add_url_rule("/redirects/<redirect_path>", view_func=get_redirect)
+app.add_url_rule("/redirects/<path:redirect_path>", view_func=get_redirect)
 app.add_url_rule(
-    "/redirects/<redirect_path>",
+    "/redirects/<path:redirect_path>",
     view_func=update_redirect,
     methods=["PUT"],
 )
 app.add_url_rule(
-    "/redirects/<redirect_path>",
+    "/redirects/<path:redirect_path>",
     view_func=delete_redirect,
     methods=["DELETE"],
 )


### PR DESCRIPTION
Add a command that allows a user to import redirects from production.

# QA

- `dotrun`
- `dotrun exec flask database import-redirects-from-prod <your-assets-token>`
- `dotrun exec flask token create qa`
- go to `localhost:8017/redirects?token=<qa-token>`
- check we have redirects