### PR TITLE
Csrf and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This is the codebase for https://assets.ubuntu.com, a Restful API service for st
 The simplest way to run the site makes use of SQLite, which is not the same as production where it will use PostgreSQL:
 
 ``` bash
-./run exec alembic upgrade head        # Run database migrations
-./run exec flask token create mytoken  # Create a token
+dotrun exec alembic upgrade head        # Run database migrations
+dotrun exec flask token create mytoken  # Create a token
 ```
 
 Save the output token
 
 ``` bash
-./run  # Run the server
+dotrun  # Run the server
 ```
 
 You can now access the API with your token in your browser - e.g.: <http://127.0.0.1:8017?token=THETOKEN>.
@@ -95,7 +95,7 @@ You can also specify multiple comma separated operations. They will be applied i
 To interact with the assets server, you'll need to generate an authentication token:
 
 ``` bash
-$ ./run exec ./manage.py gettoken {token-name}
+$ dotrun exec ./manage.py gettoken {token-name}
 Token '{token-name}' created
 3fe479a6b8184be4a4cdf42085f19f9a
 ```
@@ -129,5 +129,5 @@ You may wish to setup the [assets-manager](https://github.com/ubuntudesign/asset
 You can run all tests with:
 
 ``` bash
-./run test
+dotrun test
 ```

--- a/templates/create.html
+++ b/templates/create.html
@@ -8,6 +8,7 @@
     <div class="col-6">
       <h2>Create asset(s)</h2>
       <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input id="input-files" type="file" multiple name="assets" />
         <label for="input-tags">Tags:</label>
         <input id="input-tags" placeholder="e.g.: button, ubuntu" value="{{ tags }}" type="text" name="tags" />

--- a/templates/created.html
+++ b/templates/created.html
@@ -8,7 +8,7 @@
   <div class="row">
     <h2>Failed to upload {{failed|length}} assets</h2>
     {% for failure in failed %}
-    <p>{{failed.file_path}} - {{failed.error}}</p>
+    <p>{{failure.file_path}} - <code>{{failure.error}}</code></p>
     {% endfor %}
   </div>
   {% endif %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,28 @@
+{% extends "_layout.html" %}
+
+{% block title %}500: Server error{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center u-align--center">
+      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg" alt="" height="365" width="360">
+    </div>
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1>{{ code }}: {{ reason }}</h1>
+        <p class="p-heading--four">Something's gone wrong.</p>
+        {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
+        {% if code != 404 %}
+          <p>
+            Try reloading the page.
+            If the error persists, please note that it may be a <a class="p-link--external" href="https://github.com/canonical-websites/assets.ubuntu.com/issues">known issue</a>.
+            If not, please <a class="p-link--external" href="https://github.com/canonical-websites/assets.ubuntu.com/issues/new">file a new issue</a>.
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,6 +1,6 @@
 {% extends "_layout.html" %}
 
-{% block title %}500: Server error{% endblock %}
+{% block title %}{{ code }}: {{ reason }}{% endblock %}
 
 
 {% block content %}

--- a/templates/update.html
+++ b/templates/update.html
@@ -20,6 +20,7 @@
       {% endwith %}
       {% if asset %}
       <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {% if asset.data.image %}
         <a href="/{{ asset.file_path }}" target="_blank">
           <img class="p-image--bordered asset-thumbnail" src="/{{ asset.file_path }}">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,7 +16,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 401 status code
         """
 
-        self.assertEqual(self.client.get("/").status_code, 401)
+        self.assertEqual(self.client.get("/v1").status_code, 401)
 
     def test_not_found(self):
         """

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,6 +4,7 @@ import http.client
 
 # Packages
 from canonicalwebteam.flask_base.app import FlaskBase
+from flask import redirect
 from flask_wtf.csrf import CSRFProtect
 from flask.globals import request
 from pilbox.errors import PilboxError
@@ -35,7 +36,7 @@ init_sso(app)
 # ===
 def render_error(code, message):
     # return JSON format in case of api route (with prefix /v1)
-    if request.full_path.startswith(api_blueprint.url_prefix + "/"):
+    if request.blueprint == api_blueprint.name:
         return {"code": code, "message": message}, code
     else:
         return (
@@ -105,6 +106,11 @@ def error_swift(error=None):
 
 # Apply blueprints
 # ===
+@app.route("/")
+def index():
+    return redirect(api_blueprint.url_prefix, code=302)
+
+
 app.register_blueprint(ui_blueprint)
 app.register_blueprint(api_blueprint)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,41 +1,19 @@
 # System
 import errno
-import re
-
-import flask
+import http.client
 
 # Packages
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask.globals import request
 from pilbox.errors import PilboxError
 from swiftclient.exceptions import ClientException as SwiftException
+import flask
 
 # Local
 from webapp.commands import db_group, token_group
 from webapp.database import db_session
-from webapp.services import (
-    AssetAlreadyExistException,
-    AssetNotFound,
-    asset_service,
-)
-from webapp.sso import init_sso, login_required
-from webapp.views import (
-    create_asset,
-    create_redirect,
-    create_token,
-    delete_asset,
-    delete_redirect,
-    delete_token,
-    get_asset,
-    get_asset_info,
-    get_assets,
-    get_redirect,
-    get_redirects,
-    get_token,
-    get_tokens,
-    update_asset,
-    update_redirect,
-)
+from webapp.routes import api_blueprint, ui_blueprint
+from webapp.sso import init_sso
 
 app = FlaskBase(
     __name__,
@@ -53,92 +31,19 @@ app = FlaskBase(
 init_sso(app)
 
 
-@app.route("/manager/")
-@login_required
-def home():
-    query = request.values.get("q", "")
-    tag = request.values.get("tag", None)
-    asset_type = request.values.get("type")
-
-    if query or tag:
-        assets = asset_service.find_assets(
-            query=query, file_type=asset_type, tag=tag
-        )
-    else:
-        assets = []
-
-    return flask.render_template(
-        "index.html", assets=assets, query=query, type=asset_type
-    )
-
-
-@app.route("/manager/create", methods=["GET", "POST"])
-@login_required
-def create():
-    created_assets = []
-    existing_assets = []
-    failed_assets = []
-
-    if flask.request.method == "POST":
-        tags = flask.request.form.get("tags", "")
-        tags = re.split(",|\\s", tags)
-
-        optimize = flask.request.form.get("optimize", True)
-
-        for asset_file in flask.request.files.getlist("assets"):
-            try:
-                name = asset_file.filename
-                content = asset_file.read()
-
-                asset = asset_service.create_asset(
-                    file_content=content,
-                    friendly_name=name,
-                    optimize=optimize,
-                    tags=tags,
-                )
-
-                created_assets.append(asset)
-            except AssetAlreadyExistException as error:
-                asset = asset_service.find_asset(str(error))
-                if asset:
-                    existing_assets.append(asset)
-            except Exception as error:
-                failed_assets.append({"file_path": name, "error": str(error)})
-        return flask.render_template(
-            "created.html",
-            assets=created_assets,
-            existing=existing_assets,
-            failed=failed_assets,
-            tags=tags,
-            optimize=optimize,
-        )
-
-    return flask.render_template("create.html")
-
-
-@app.route("/manager/update", methods=["GET", "POST"])
-@login_required
-def update():
-    file_path = request.args.get("file-path")
-
-    if request.method == "GET":
-        asset = asset_service.find_asset(file_path)
-        if not asset:
-            flask.flash("Asset not found", "negative")
-
-    elif request.method == "POST":
-        tags = request.form.get("tags")
-        try:
-            asset = asset_service.update_asset(file_path, tags=tags.split(","))
-            flask.flash("Tags updated", "positive")
-        except AssetNotFound:
-            flask.flash("Asset not found", "negative")
-
-    return flask.render_template("update.html", asset=asset)
-
-
 # Error pages
 # ===
+def render_error(code, message):
+    # return JSON format in case of api route (with prefix /v1)
+    if request.full_path.startswith(api_blueprint.url_prefix + "/"):
+        return {"code": code, "message": message}, code
+    else:
+        return flask.render_template(
+            "error.html",
+            code=code,
+            reason=http.client.responses.get(code),
+            message=message,
+        )
 
 
 @app.errorhandler(400)
@@ -147,13 +52,13 @@ def update():
 @app.errorhandler(404)
 def error_handler(error=None):
     code = getattr(error, "code")
-    return {"status": code, "message": str(error)}, code
+    return render_error(code, str(error))
 
 
 @app.errorhandler(500)
 def error_500(error=None):
     app.extensions["sentry"].captureException()
-    return {"code": 500, "message": str(error)}, 500
+    return render_error(500, str(error))
 
 
 @app.errorhandler(OSError)
@@ -171,7 +76,7 @@ def error_os(error=None):
     if error.errno in [errno.E2BIG]:
         status = 413  # Request Entity Too Large
 
-    return {"code": status, "message": error.strerror}, status
+    return render_error(status, str(error.strerror))
 
 
 @app.errorhandler(PilboxError)
@@ -179,10 +84,7 @@ def error_pillbox(error=None):
     app.extensions["sentry"].captureException()
 
     status = error.status_code
-    return (
-        {"code": status, "message": f"Pilbox Error: {error.log_message}"},
-        500,
-    )
+    return render_error(status, f"Pilbox Error: {error.log_message}")
 
 
 @app.errorhandler(SwiftException)
@@ -195,52 +97,16 @@ def error_swift(error=None):
     elif error.msg[:12] == "Unauthorised":
         # Special case for swiftclient.exceptions.ClientException
         status = 511
+    return render_error(status, f"Swift Error: {error.msg}")
 
-    return {"code": status, "message": f"Swift Error: {error.msg}"}, status
 
-
-# API Routes
+# Apply blueprints
 # ===
-
-# Assets
-app.add_url_rule("/", view_func=get_assets)
-app.add_url_rule("/", view_func=create_asset, methods=["POST"])
-app.add_url_rule("/<path:file_path>", view_func=get_asset)
-app.add_url_rule("/<path:file_path>", view_func=update_asset, methods=["PUT"])
-app.add_url_rule(
-    "/<path:file_path>", view_func=delete_asset, methods=["DELETE"]
-)
-app.add_url_rule("/<path:file_path>/info", view_func=get_asset_info)
-
-# Tokens
-app.add_url_rule("/tokens", view_func=get_tokens)
-app.add_url_rule("/tokens/<string:name>", view_func=get_token)
-app.add_url_rule(
-    "/tokens/<string:name>", view_func=create_token, methods=["POST"]
-)
-app.add_url_rule(
-    "/tokens/<string:name>", view_func=delete_token, methods=["DELETE"]
-)
-
-# Redirects
-app.add_url_rule("/redirects", view_func=get_redirects)
-app.add_url_rule("/redirects", view_func=create_redirect, methods=["POST"])
-app.add_url_rule("/redirects/<path:redirect_path>", view_func=get_redirect)
-app.add_url_rule(
-    "/redirects/<path:redirect_path>",
-    view_func=update_redirect,
-    methods=["PUT"],
-)
-app.add_url_rule(
-    "/redirects/<path:redirect_path>",
-    view_func=delete_redirect,
-    methods=["DELETE"],
-)
+app.register_blueprint(ui_blueprint)
+app.register_blueprint(api_blueprint)
 
 # Teardown
 # ===
-
-
 @app.teardown_appcontext
 def remove_db_session(response):
     db_session.remove()

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -4,7 +4,6 @@ import re
 # Packages
 from flask import Blueprint
 from flask.globals import request
-from swiftclient.exceptions import ClientException as SwiftException
 import flask
 
 # Local

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -1,0 +1,169 @@
+# System
+import re
+
+# Packages
+from flask import Blueprint
+from flask.globals import request
+from swiftclient.exceptions import ClientException as SwiftException
+import flask
+
+# Local
+from webapp.services import (
+    AssetAlreadyExistException,
+    AssetNotFound,
+    asset_service,
+)
+from webapp.sso import login_required
+from webapp.views import (
+    create_asset,
+    create_redirect,
+    create_token,
+    delete_asset,
+    delete_redirect,
+    delete_token,
+    get_asset,
+    get_asset_info,
+    get_assets,
+    get_redirect,
+    get_redirects,
+    get_token,
+    get_tokens,
+    update_asset,
+    update_redirect,
+)
+
+
+ui_blueprint = Blueprint("ui_blueprint", __name__, url_prefix="/manager")
+api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="/v1")
+
+# Manager Routes
+# ===
+
+
+@ui_blueprint.route("/")
+@login_required
+def home():
+    query = request.values.get("q", "")
+    tag = request.values.get("tag", None)
+    asset_type = request.values.get("type")
+
+    if query or tag:
+        assets = asset_service.find_assets(
+            query=query, file_type=asset_type, tag=tag
+        )
+    else:
+        assets = []
+
+    return flask.render_template(
+        "index.html", assets=assets, query=query, type=asset_type
+    )
+
+
+@ui_blueprint.route("/create", methods=["GET", "POST"])
+@login_required
+def create():
+    created_assets = []
+    existing_assets = []
+    failed_assets = []
+
+    if flask.request.method == "POST":
+        tags = flask.request.form.get("tags", "")
+        tags = re.split(",|\\s", tags)
+
+        optimize = flask.request.form.get("optimize", True)
+
+        for asset_file in flask.request.files.getlist("assets"):
+            try:
+                name = asset_file.filename
+                content = asset_file.read()
+
+                asset = asset_service.create_asset(
+                    file_content=content,
+                    friendly_name=name,
+                    optimize=optimize,
+                    tags=tags,
+                )
+
+                created_assets.append(asset)
+            except AssetAlreadyExistException as error:
+                asset = asset_service.find_asset(str(error))
+                if asset:
+                    existing_assets.append(asset)
+            except Exception as error:
+                failed_assets.append({"file_path": name, "error": str(error)})
+        return flask.render_template(
+            "created.html",
+            assets=created_assets,
+            existing=existing_assets,
+            failed=failed_assets,
+            tags=tags,
+            optimize=optimize,
+        )
+
+    return flask.render_template("create.html")
+
+
+@ui_blueprint.route("/update", methods=["GET", "POST"])
+@login_required
+def update():
+    file_path = request.args.get("file-path")
+
+    if request.method == "GET":
+        asset = asset_service.find_asset(file_path)
+        if not asset:
+            flask.flash("Asset not found", "negative")
+
+    elif request.method == "POST":
+        tags = request.form.get("tags")
+        try:
+            asset = asset_service.update_asset(file_path, tags=tags.split(","))
+            flask.flash("Tags updated", "positive")
+        except AssetNotFound:
+            flask.flash("Asset not found", "negative")
+
+    return flask.render_template("update.html", asset=asset)
+
+
+# API Routes
+# ===
+
+# Assets
+api_blueprint.add_url_rule("/", view_func=get_assets)
+api_blueprint.add_url_rule("/", view_func=create_asset, methods=["POST"])
+api_blueprint.add_url_rule("/<path:file_path>", view_func=get_asset)
+api_blueprint.add_url_rule(
+    "/<path:file_path>", view_func=update_asset, methods=["PUT"]
+)
+api_blueprint.add_url_rule(
+    "/<path:file_path>", view_func=delete_asset, methods=["DELETE"]
+)
+api_blueprint.add_url_rule("/<path:file_path>/info", view_func=get_asset_info)
+
+# Tokens
+api_blueprint.add_url_rule("/tokens", view_func=get_tokens)
+api_blueprint.add_url_rule("/tokens/<string:name>", view_func=get_token)
+api_blueprint.add_url_rule(
+    "/tokens/<string:name>", view_func=create_token, methods=["POST"]
+)
+api_blueprint.add_url_rule(
+    "/tokens/<string:name>", view_func=delete_token, methods=["DELETE"]
+)
+
+# Redirects
+api_blueprint.add_url_rule("/redirects", view_func=get_redirects)
+api_blueprint.add_url_rule(
+    "/redirects", view_func=create_redirect, methods=["POST"]
+)
+api_blueprint.add_url_rule(
+    "/redirects/<path:redirect_path>", view_func=get_redirect
+)
+api_blueprint.add_url_rule(
+    "/redirects/<path:redirect_path>",
+    view_func=update_redirect,
+    methods=["PUT"],
+)
+api_blueprint.add_url_rule(
+    "/redirects/<path:redirect_path>",
+    view_func=delete_redirect,
+    methods=["DELETE"],
+)


### PR DESCRIPTION
## Done

- Add the prefix `/v1` to the api routes
- Better organization of routes
- Add generic HTML error page
- CSRF protection for `/manager/create` and `/manager/update` forms

## QA

- Run the project with `dotrun`
- Make sure that the routes are still working
- Try creating an asset with the manager and without the manager to make sure that CSRF is applying in the good places

## Issues

Fixes #173  
